### PR TITLE
Remove duplicate entries to match in game values.

### DIFF
--- a/data/1.1.1/perks.json
+++ b/data/1.1.1/perks.json
@@ -11266,21 +11266,6 @@
     ]
   },
   {
-    "type": "SPECIAL",
-    "icon": "mmorpg:textures/gui/stat_icons/elemental/physical_resist.png",
-    "id": "physical_resist_big",
-    "is_entry": false,
-    "max_lvls": 1,
-    "stats": [
-      {
-        "type": "FLAT",
-        "scale_to_lvl": false,
-        "stat": "physical_resist",
-        "v1": 10.0
-      }
-    ]
-  },
-  {
     "type": "STAT",
     "icon": "mmorpg:textures/gui/stat_icons/elemental/physical_resist.png",
     "id": "physical_resist",
@@ -11322,21 +11307,6 @@
         "scale_to_lvl": false,
         "stat": "physical_resist",
         "v1": 5.0
-      }
-    ]
-  },
-  {
-    "type": "STAT",
-    "icon": "mmorpg:textures/gui/stat_icons/elemental/physical_resist.png",
-    "id": "physical_resist",
-    "is_entry": false,
-    "max_lvls": 1,
-    "stats": [
-      {
-        "type": "FLAT",
-        "scale_to_lvl": false,
-        "stat": "physical_resist",
-        "v1": 2.0
       }
     ]
   },


### PR DESCRIPTION
Duplicate entries are caused by file name mismatch between base Mine and Slash and CTE2 openloader config. One is named "phys" and the other is "physical".

The values likely intended in CTE2 is physical_resist_big=5 and physical_resist=2 but due to the duplicate entry only physical_resist_big is being overwritten properly in the pack. The values seen in game reflect this as physical_resist_big=5 and physical_resist=4. This commit should make the planner match that.